### PR TITLE
Link to the github pages of the presentations.

### DIFF
--- a/res.md
+++ b/res.md
@@ -19,7 +19,7 @@
 
 **Recover Instructions**
 
-[下载地址](https://github.com/nbp/slides/tree/master/RInstruction)
+[下载地址](https://nbp.github.io/slides/RInstruction)
 
 by @nbp again.
 
@@ -27,7 +27,7 @@ TODO: 没看懂.
 
 **Dynamic Taint Analysis**
 
-[下载地址](https://github.com/nbp/slides/tree/master/TaintAnalysis)
+[下载地址](https://nbp.github.io/slides/TaintAnalysis)
 
 by @nbp again. [涉及Jalangi框架的部分可以看这里](https://github.com/Berkeley-Correctness-Group/Jalangi-Berkeley). 上半年正好关注过这个团队 :-)
 


### PR DESCRIPTION
Some of the presentations I made have associated github pages, this modification updates the links to use the github pages instead of the raw content.  This is way better for viewing the RInstruction presentation content ;)
